### PR TITLE
Show errors on submit form

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,6 +37,7 @@
                  [net.mikera/imagez "0.12.0"]
                  [cljsjs/enzyme "3.8.0"]
                  [cljs-idxdb "0.1.0"]
+                 [phrase "0.3-alpha4"]
                  ]
 
   :plugins [[lein-cljsbuild "1.1.7"]
@@ -49,7 +50,7 @@
 
   :min-lein-version "2.5.3"
 
-  :source-paths ["src/clj" "src/cljs"]
+  :source-paths ["src/clj" "src/cljc" "src/cljs"]
   :test-paths ["test/clj"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
@@ -99,7 +100,7 @@
   :cljsbuild
   {:builds
    [{:id           "dev"
-     :source-paths ["src/cljs"]
+     :source-paths ["src/cljs" "src/cljc"]
      :figwheel     {:websocket-host :js-client-host
                     :on-jsload "webchange.core/mount-root"}
      :compiler     {:main                 webchange.core

--- a/src/clj/webchange/common/handler.clj
+++ b/src/clj/webchange/common/handler.clj
@@ -12,6 +12,12 @@
        (on-success data response)
        response))))
 
+(defn validation-error
+  [body]
+  {:status  422
+   :headers {}
+   :body    {:errors body}})
+
 (defn current-user
   [request]
   (if-not (authenticated? request)

--- a/src/cljc/webchange/validation/phrases.cljc
+++ b/src/cljc/webchange/validation/phrases.cljc
@@ -1,0 +1,29 @@
+(ns webchange.validation.phrases
+  (:require
+    [phrase.alpha :refer [defphraser]]
+    [webchange.validation.predicates :as p]))
+
+(defphraser :default
+            [_ problem]
+            (println "Unhandled validation predicate" (:pred problem))
+            "Invalid value")
+
+(defphraser #(contains? % ::gender)
+            [_ _]
+            "Required field")
+
+(defphraser p/date-string?
+            [_ _]
+            "Date must have format \"dd-mm-yyyy\" ")
+
+(defphraser p/not-empty?
+            [_ _]
+            "Required field")
+
+(defphraser string?
+            [_ _]
+            "Must be a string")
+
+(defphraser number?
+            [_ _]
+            "Must be a number")

--- a/src/cljc/webchange/validation/predicates.cljc
+++ b/src/cljc/webchange/validation/predicates.cljc
@@ -1,0 +1,4 @@
+(ns webchange.validation.predicates)
+
+(def date-string? #(->> % (re-matches #"([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))") (boolean)))
+(def not-empty? (complement empty?))

--- a/src/cljc/webchange/validation/specs/student.cljc
+++ b/src/cljc/webchange/validation/specs/student.cljc
@@ -1,0 +1,19 @@
+(ns webchange.validation.specs.student
+  (:require
+    [clojure.spec.alpha :as s]
+    [webchange.validation.predicates :as p]))
+
+(s/def ::class-id number?)
+(s/def ::gender #{1 2})
+(s/def ::first-name (s/and string? p/not-empty?))
+(s/def ::last-name (s/and string? p/not-empty?))
+(s/def ::date-of-birth (s/and string? p/date-string?))
+(s/def ::access-code (s/and string? p/not-empty?))
+
+(s/def ::student (s/keys :req-un [::class-id
+                                  ::gender
+                                  ::first-name
+                                  ::last-name
+                                  ::date-of-birth
+                                  ::access-code]
+                         :opt []))

--- a/src/cljc/webchange/validation/validate.cljc
+++ b/src/cljc/webchange/validation/validate.cljc
@@ -1,0 +1,35 @@
+(ns webchange.validation.validate
+  (:require
+    [clojure.spec.alpha :as s]
+    [webchange.validation.specs.student]
+    [webchange.validation.phrases]
+    [phrase.alpha :refer [phrase]]))
+
+(defn get-problem-field
+  [problem]
+  (let [path (:path problem)
+        predicate (:pred problem)
+        get-field-keyword #(when (sequential? %) (->> % (last) (last)))]
+    (or (first path) (get-field-keyword predicate))))
+
+(defn get-error-messages
+  [spec data]
+  (let [explain-data (s/explain-data spec data)
+        errors-data (or (:clojure.spec.alpha/problems explain-data) (:cljs.spec.alpha/problems explain-data))]
+    (cond
+      (map? data) (reduce (fn [result problem]
+                            (assoc result
+                              (get-problem-field problem)
+                              (phrase {} problem)))
+                          {}
+                          errors-data)
+      :else (map (fn [problem]
+                   (phrase {} problem))
+                 errors-data))))
+
+(defn validate
+  [spec data]
+  (let [errors (get-error-messages spec data)]
+    (if-not (empty? errors)
+      errors
+      nil)))

--- a/src/cljs/webchange/dashboard/common/form_controls.cljs
+++ b/src/cljs/webchange/dashboard/common/form_controls.cljs
@@ -1,0 +1,48 @@
+(ns webchange.dashboard.common.form-controls
+  (:require
+    [cljs-react-material-ui.reagent :as ui]
+    [reagent.core :as r]
+    [webchange.ui.theme :refer [w-colors]]
+    [webchange.validation.validate :refer [validate]]))
+
+(defn validation-message
+  [{:keys [spec value dirty? custom-error]}]
+  (let [error-message (cond
+                        dirty? (validate spec value)
+                        (some? custom-error) custom-error)]
+    [ui/form-helper-text {:style {:color (:secondary w-colors)}} error-message]))
+
+(defn text-field-validated
+  []
+  (let [dirty? (r/atom false)]
+    (fn [{:keys [default-value on-change spec custom-error] :as props}]
+      [ui/form-control {:margin "normal" :full-width true}
+       [ui/text-field
+        (merge (-> props
+                   (dissoc :on-change)
+                   (dissoc :spec)
+                   (dissoc :custom-error)) {:on-change #(do (reset! dirty? true)
+                                                            (on-change %))})]
+       [validation-message {:spec         spec
+                            :value        default-value
+                            :custom-error custom-error
+                            :dirty?       @dirty?}]])))
+
+(defn select-validated
+  []
+  (let [dirty? (r/atom false)]
+    (fn [{:keys [label value on-change spec custom-error] :as props} & children]
+      [ui/form-control {:margin "normal" :full-width true}
+       [ui/input-label {:required true} label]
+       [ui/select
+        (merge (-> props
+                   (dissoc :on-change)
+                   (dissoc :spec)
+                   (dissoc :label)
+                   (dissoc :custom-error)) {:on-change #(do (reset! dirty? true)
+                                                            (on-change %))})
+        children]
+       [validation-message {:spec         spec
+                            :value        value
+                            :custom-error custom-error
+                            :dirty?       @dirty?}]])))

--- a/src/cljs/webchange/dashboard/events.cljs
+++ b/src/cljs/webchange/dashboard/events.cljs
@@ -2,7 +2,8 @@
   (:require
     [re-frame.core :as re-frame]
     [webchange.dashboard.classes.events :as classes-events]
-    [webchange.dashboard.students.events :as students-events]))
+    [webchange.dashboard.students.events :as students-events]
+    [webchange.validation.validate :refer [validate]]))
 
 (re-frame/reg-event-fx
   ::set-main-content
@@ -41,3 +42,9 @@
   (fn [{:keys [db]} _]
     {:dispatch-n (list
                    [::classes-events/load-classes])}))
+
+(re-frame/reg-cofx
+  :validate
+  (fn [co-effects entity-type]
+    (let [[_ _ entity-data] (:event co-effects)]
+      (assoc co-effects :validation-errors (validate entity-type entity-data)))))

--- a/src/cljs/webchange/dashboard/events_utils.cljs
+++ b/src/cljs/webchange/dashboard/events_utils.cljs
@@ -1,0 +1,10 @@
+(ns webchange.dashboard.events-utils)
+
+(defn when-valid
+  [entity-type co-effects event-effect]
+  (let [{:keys [db validation-errors]} co-effects]
+    (if-not validation-errors
+      event-effect
+      {:db (assoc-in db
+                     (conj [:errors] entity-type)
+                     validation-errors)})))

--- a/src/cljs/webchange/subs.cljs
+++ b/src/cljs/webchange/subs.cljs
@@ -132,6 +132,11 @@
     (:errors db)))
 
 (re-frame/reg-sub
+  ::entity-errors
+  (fn [db [_ entity]]
+    (get-in db (conj [:errors] entity))))
+
+(re-frame/reg-sub
   ::active-route
   (fn [db]
     (:active-route db)))


### PR DESCRIPTION
On Teacher dashboard when there are any error messages received from the backend, we need to show them on the form. See add student modal. 
[Card #2473398](https://github.com/VisionsGlobalEmpowerment/webchange/projects/1#card-24733981)

---

- [common validation](https://github.com/VisionsGlobalEmpowerment/webchange/pull/64/files#diff-ba0d43a62f7b57a09aee3dff7e7b44aaR30)
- [client-side field validation on change](https://github.com/VisionsGlobalEmpowerment/webchange/pull/64/files#diff-00ca8e56e78027210a7aec02b1a24aa1R76)
- [client-side form validation before send](https://github.com/VisionsGlobalEmpowerment/webchange/pull/64/files#diff-9edde1600a8e3842ac156baca02b23ffR47)
- [server-side validation](https://github.com/VisionsGlobalEmpowerment/webchange/pull/64/files#diff-40346e66d974bfc90c565e14016ad233R101)