### PR TITLE
Allow submit class form with Enter keypress

### DIFF
--- a/src/cljs/webchange/dashboard/classes/class_modal/views.cljs
+++ b/src/cljs/webchange/dashboard/classes/class_modal/views.cljs
@@ -6,13 +6,12 @@
     [webchange.dashboard.classes.subs :as dcs]
     [webchange.dashboard.classes.events :as dce]))
 
-(defn- class-form
+(defn- class-form-inputs
   [props]
-  [:form
-   [ui/text-field
-    {:label         "Class Name"
-     :default-value (:name @props)
-     :on-change     #(swap! props assoc :name (->> % .-target .-value))}]])
+  [ui/text-field
+   {:label         "Class Name"
+    :default-value (:name @props)
+    :on-change     #(swap! props assoc :name (->> % .-target .-value))}])
 
 (defn class-modal
   []
@@ -27,24 +26,26 @@
     [ui/dialog
      {:open     (boolean class-modal-state)
       :on-close handle-close}
-     [ui/dialog-title
-      (case class-modal-state
-        :add "Add New Class"
-        :edit "Edit Class"
-        "")]
-     [ui/dialog-content
-      (if (:class loading)
-        [ui/circular-progress
-         {:size  80
-          :color "secondary"}]
-        [class-form class-data])]
-     [ui/dialog-actions
-      [ui/button
-       {:on-click handle-close}
-       "Cancel"]
-      [ui/button
-       {:variant  "contained"
-        :color    "primary"
-        :on-click #(do (handle-save @class-data)
-                       (handle-close))}
-       "Save"]]]))
+     [:form
+      [ui/dialog-title
+       (case class-modal-state
+         :add "Add New Class"
+         :edit "Edit Class"
+         "")]
+      [ui/dialog-content
+       (if (:class loading)
+         [ui/circular-progress
+          {:size  80
+           :color "secondary"}]
+         [class-form-inputs class-data])]
+      [ui/dialog-actions
+       [ui/button
+        {:on-click handle-close}
+        "Cancel"]
+       [ui/button
+        {:type     "submit"
+         :variant  "contained"
+         :color    "primary"
+         :on-click #(do (handle-save @class-data)
+                        (handle-close))}
+        "Save"]]]]))


### PR DESCRIPTION
Currently, when you press 'Enter' on a new class form - the page is reloaded and class is NOT added.