### PR TITLE
Allow deleting unassigned students

### DIFF
--- a/resources/sql/class.sql
+++ b/resources/sql/class.sql
@@ -45,6 +45,11 @@ UPDATE students
 SET class_id = null
 WHERE user_id = :user_id
 
+-- :name delete-student! :! :n
+-- :doc deletes student
+DELETE from students
+WHERE user_id = :user_id
+
 -- :name get-classes :? :*
 -- :doc retrieve all classes by school
 SELECT * from classes

--- a/resources/sql/progress.sql
+++ b/resources/sql/progress.sql
@@ -58,6 +58,11 @@ UPDATE course_stats
 SET class_id = null
 WHERE user_id = :user_id
 
+-- :name delete-course-stat! :! :n
+-- :doc deletes course stat
+DELETE from course_stats
+WHERE user_id = :user_id
+
 -- :name create-activity-stat! :<!
 -- :doc creates a new activity stat record
 INSERT INTO activity_stats

--- a/src/clj/webchange/class/core.clj
+++ b/src/clj/webchange/class/core.clj
@@ -50,11 +50,11 @@
     {:students students}))
 
 (defn get-student [id]
-  (let [student (-> (db/get-student {:id id})
-                    (with-class)
-                    (#(assoc % :date-of-birth (-> % :date-of-birth str)))
-                    with-user)]
-    {:student student}))
+  (if-let [student (db/get-student {:id id})]
+    (-> student
+        (with-class)
+        (#(assoc % :date-of-birth (-> % :date-of-birth str)))
+        with-user)))
 
 (defn create-class!
   [data]
@@ -107,6 +107,13 @@
   (let [{user-id :user-id} (db/get-student {:id id})]
     (db/unassign-student! {:user_id user-id})
     (db/unassign-course-stat! {:user_id user-id}))
+  [true {:id id}])
+
+(defn delete-student!
+  [id]
+  (let [{user-id :user-id} (db/get-student {:id id})]
+    (db/delete-student! {:user_id user-id})
+    (db/delete-course-stat! {:user_id user-id}))
   [true {:id id}])
 
 (defn get-current-school [] (db/get-first-school))

--- a/src/clj/webchange/class/handler.clj
+++ b/src/clj/webchange/class/handler.clj
@@ -72,6 +72,12 @@
     (-> (core/unassign-student! (Integer/parseInt id))
         handle)))
 
+(defn handle-delete-student
+  [id request]
+  (let [owner-id (current-user request)]
+    (-> (core/delete-student! (Integer/parseInt id))
+        handle)))
+
 (defn handle-current-school [request]
   (-> (core/get-current-school)
       response))
@@ -97,15 +103,20 @@
 
            (GET "/api/classes/:id/students" [id] (-> id Integer/parseInt core/get-students-by-class response))
            (GET "/api/unassigned-students" [] (-> (core/get-students-unassigned) response))
-           (GET "/api/students/:id" [id] (-> id Integer/parseInt core/get-student response))
+           (GET "/api/students/:id" [id]
+             (if-let [item (-> id Integer/parseInt core/get-student)]
+               (response {:student item})
+               (not-found "not found")))
            (POST "/api/students" request
              (if-let [errors (validate-student (:body request))]
                (validation-error errors)
                (handle-create-student request)))
            (PUT "/api/students/:id" [id :as request]
              (handle-update-student id request))
-           (DELETE "/api/students/:id" [id :as request]
+           (DELETE "/api/students/:id/class" [id :as request]
              (handle-unassign-student id request))
+           (DELETE "/api/students/:id" [id :as request]
+             (handle-delete-student id request))
 
            (POST "/api/next-access-code" request (handle-next-access-code request))
            )

--- a/src/cljs/webchange/dashboard/students/student_modal/views.cljs
+++ b/src/cljs/webchange/dashboard/students/student_modal/views.cljs
@@ -156,9 +156,9 @@
         :on-click #(handle-save @student-data)}
        "Save"]]]))
 
-(defn student-delete-modal
+(defn student-remove-from-class-modal
   []
-  (let [modal-state @(re-frame/subscribe [::students-subs/delete-modal-state])
+  (let [modal-state @(re-frame/subscribe [::students-subs/remove-from-class-modal-state])
         is-loading? @(re-frame/subscribe [::students-subs/student-loading])
         {{first-name :first-name last-name :last-name} :user student-id :id class-id :class-id} @(re-frame/subscribe [::students-subs/current-student])]
     (when modal-state
@@ -168,12 +168,34 @@
          [:div
           [ui/dialog-title "Are you sure?"]
           [ui/dialog-content
-           [ui/dialog-content-text (str "You are about to delete " first-name " " last-name)]]
+           [ui/dialog-content-text (str "You are about to remove " first-name " " last-name " from its class")]]
           [ui/dialog-actions
-           [ui/button {:on-click #(re-frame/dispatch [::students-events/close-delete-modal])} "Cancel"]
+           [ui/button {:on-click #(re-frame/dispatch [::students-events/close-remove-from-class-modal])} "Cancel"]
            [ui/button
             {:variant  "contained"
              :color    "primary"
-             :on-click #(re-frame/dispatch [::students-events/confirm-delete class-id student-id])}
+             :on-click #(re-frame/dispatch [::students-events/confirm-remove class-id student-id])}
+            "Confirm"]]])
+       ])))
+
+(defn student-delete-modal
+  []
+  (let [modal-state @(re-frame/subscribe [::students-subs/delete-modal-state])
+        is-loading? @(re-frame/subscribe [::students-subs/student-loading])
+        {{first-name :first-name last-name :last-name} :user student-id :id} @(re-frame/subscribe [::students-subs/current-student])]
+    (when modal-state
+      [ui/dialog {:open true}
+       (if is-loading?
+         [ui/linear-progress]
+         [:div
+          [ui/dialog-title "Are you sure?"]
+          [ui/dialog-content
+           [ui/dialog-content-text (str "You are about to delete " first-name " " last-name)]]
+          [ui/dialog-actions
+           [ui/button {:on-click #(re-frame/dispatch [::students-events/close-remove-from-class-modal])} "Cancel"]
+           [ui/button
+            {:variant  "contained"
+             :color    "primary"
+             :on-click #(re-frame/dispatch [::students-events/confirm-delete student-id])}
             "Confirm"]]])
        ])))

--- a/src/cljs/webchange/dashboard/students/student_profile/views.cljs
+++ b/src/cljs/webchange/dashboard/students/student_profile/views.cljs
@@ -56,7 +56,7 @@
       :current-title (:name student)
       :actions       (actions {:student         student
                                :on-edit-click   (fn [{:keys [id]}] (re-frame/dispatch [::students-events/show-edit-student-form id]))
-                               :on-remove-click (fn [{:keys [id]}] (re-frame/dispatch [::students-events/show-delete-student-form id]))
+                               :on-remove-click (fn [{:keys [id]}] (re-frame/dispatch [::students-events/show-remove-from-class-form id]))
                                :on-class-click  (fn [] (redirect-to :dashboard-class-profile :class-id class-id))})}
      [personal-data student]
      [student-scores [{:title  (translate [:cumulative-scores :title])

--- a/src/cljs/webchange/dashboard/students/students_list/views.cljs
+++ b/src/cljs/webchange/dashboard/students/students_list/views.cljs
@@ -152,7 +152,7 @@
             [students-list
              {:on-profile-click (fn [{:keys [id class-id]}] (redirect-to :dashboard-student-profile :class-id class-id :student-id id))
               :on-edit-click    (fn [{:keys [id]}] (re-frame/dispatch [::students-events/show-edit-student-form id]))
-              :on-remove-click  (fn [{:keys [id]}] (re-frame/dispatch [::students-events/show-delete-student-form id]))}
+              :on-remove-click  (fn [{:keys [id]}] (re-frame/dispatch [::students-events/show-remove-from-class-form id]))}
              (->> students
                   (map-students-list)
                   (filter-students-list @filter))]

--- a/src/cljs/webchange/dashboard/students/students_menu/views.cljs
+++ b/src/cljs/webchange/dashboard/students/students_menu/views.cljs
@@ -17,10 +17,19 @@
 
 (defn- students-menu-item
   [{:keys [on-click]}
-   {:keys [name] :as class}]
+   {:keys [name] :as student}]
   [ui/menu-item
-   {:on-click #(on-click class)}
+   {:on-click #(on-click student)}
    name])
+
+(defn- unassigned-students-menu-item
+  [{:keys [on-click]}
+   {:keys [id name] :as student}]
+  [ui/menu-item
+   {:on-click #(on-click student)}
+   name
+   [ui/list-item-secondary-action
+    [ui/icon-button {:on-click #(re-frame/dispatch [::students-events/show-delete-form id])} [ic/delete-forever]]]])
 
 (defn students-menu
   []
@@ -48,7 +57,7 @@
        [ui/list-subheader "Unassigned"]
        (for [student unassigned]
          ^{:key (:id student)}
-         [students-menu-item
+         [unassigned-students-menu-item
           {:on-click #(re-frame/dispatch [::students-events/show-edit-student-form (:id %)])}
           student])
        ]]

--- a/src/cljs/webchange/dashboard/students/subs.cljs
+++ b/src/cljs/webchange/dashboard/students/subs.cljs
@@ -53,6 +53,11 @@
     (get-in db [:dashboard :student-profile])))
 
 (re-frame/reg-sub
+  ::remove-from-class-modal-state
+  (fn [db]
+    (get-in db [:dashboard :remove-student-from-class-modal-state])))
+
+(re-frame/reg-sub
   ::delete-modal-state
   (fn [db]
     (get-in db [:dashboard :delete-student-modal-state])))

--- a/src/cljs/webchange/dashboard/students/views.cljs
+++ b/src/cljs/webchange/dashboard/students/views.cljs
@@ -6,6 +6,7 @@
     [webchange.dashboard.students.students-menu.views :as students-menu-views]))
 
 (def student-modal student-modal-views/student-modal)
+(def student-remove-from-class-modal student-modal-views/student-remove-from-class-modal)
 (def student-delete-modal student-modal-views/student-delete-modal)
 (def student-profile student-profile-views/student-profile-page)
 (def students-list students-list-views/students-list-page)

--- a/src/cljs/webchange/dashboard/views.cljs
+++ b/src/cljs/webchange/dashboard/views.cljs
@@ -6,7 +6,7 @@
     [webchange.dashboard.dashboard-layout.views :refer [app-bar drawer progress-bar side-menu]]
     [webchange.dashboard.dashboard-layout.utils :refer [get-shift-styles]]
     [webchange.dashboard.classes.views :refer [classes-list class-modal class-delete-modal class-profile]]
-    [webchange.dashboard.students.views :refer [students-list student-modal student-delete-modal student-profile]]
+    [webchange.dashboard.students.views :refer [students-list student-modal student-delete-modal student-remove-from-class-modal student-profile]]
     [webchange.dashboard.subs :as dashboard-subs]
     [webchange.routes :refer [redirect-to]]
     [webchange.ui.theme :refer [with-mui-theme]]))
@@ -36,6 +36,7 @@
    [class-modal]
    [class-delete-modal]
    [student-modal]
+   [student-remove-from-class-modal]
    [student-delete-modal]
    ])
 

--- a/test/clj/webchange/test/class/handler.clj
+++ b/test/clj/webchange/test/class/handler.clj
@@ -93,6 +93,12 @@
         students (-> (f/get-unassigned-students) :body (json/read-str :key-fn keyword) :students)]
     (is (= 1 (count students)))))
 
+(deftest student-can-be-deleted
+  (let [{id :id} (f/student-created)
+        _ (f/delete-student! id)
+        status (-> id f/get-student :status)]
+    (is (= 404 status))))
+
 (deftest current-school-can-be-retrieved
   (let [school (-> (f/get-current-school) :body (json/read-str :key-fn keyword))]
     (is (= f/default-school-id (:id school)))))

--- a/test/clj/webchange/test/fixtures/core.clj
+++ b/test/clj/webchange/test/fixtures/core.clj
@@ -430,6 +430,13 @@
 
 (defn unassigned-student!
   [id]
+  (let [url (str "/api/students/" id "/class")
+        request (-> (mock/request :delete url)
+                    teacher-logged-in)]
+    (handler/dev-handler request)))
+
+(defn delete-student!
+  [id]
   (let [url (str "/api/students/" id)
         request (-> (mock/request :delete url)
                     teacher-logged-in)]


### PR DESCRIPTION
- previous "delete-student" renamed to "remove-from-class"
- add actual removal of a student (with its course-stats)
- added new modal for deleting
- delete button added to unassigned students list
