### PR TITLE
Fix audios list in translator

### DIFF
--- a/src/cljs/webchange/editor_v2/translator/subs.cljs
+++ b/src/cljs/webchange/editor_v2/translator/subs.cljs
@@ -5,7 +5,9 @@
 (re-frame/reg-sub
   ::translator-modal-state
   (fn [db]
-    (get-in db [:editor-v2 :translator :translator-modal-state])))
+    (-> db
+        (get-in [:editor-v2 :translator :translator-modal-state])
+        boolean)))
 
 (re-frame/reg-sub
   ::selected-action

--- a/src/cljs/webchange/editor_v2/translator/translator_form/views_form.cljs
+++ b/src/cljs/webchange/editor_v2/translator/translator_form/views_form.cljs
@@ -16,14 +16,6 @@
     [webchange.editor-v2.translator.translator-form.views-form-play-phrase :refer [play-phrase-block]]
     [webchange.subs :as subs]))
 
-(defn normalize-path
-  [path graph]
-  (map
-    (fn [path-item]
-      (let [origin (get-in graph [path-item :data :origin])]
-        (or origin path-item)))
-    path))
-
 (defn init-action-data!
   [data-store path selected-action-concept? concept-data scene-data]
   (let [action-name (first path)]
@@ -71,9 +63,8 @@
                                            (keyword (:name @selected-phrase-node)))
                     selected-action-node (re-frame/subscribe [::translator-subs/selected-action])
                     selected-action-concept? (-> @selected-action-node (get-in [:data :concept-action]) (boolean))
-
+                    selected-action-path (:path @selected-action-node)
                     {:keys [graph has-concepts?]} (get-graph scene-data phrase-action-name {:current-concept @current-concept})
-                    selected-action-path (normalize-path (:path @selected-action-node) graph)
                     audios-list (get-audios scene-data graph)
                     prepared-current-action-data (get-current-action-data @selected-action-node @current-concept @data-store)]
                 (init-action-data! data-store selected-action-path selected-action-concept? @current-concept scene-data)

--- a/src/cljs/webchange/editor_v2/translator/views_modal.cljs
+++ b/src/cljs/webchange/editor_v2/translator/views_modal.cljs
@@ -26,19 +26,19 @@
   []
   (let [actions-data (atom {})
         scene-id (re-frame/subscribe [::subs/current-scene])
-        translator-modal-state @(re-frame/subscribe [::translator-subs/translator-modal-state])
+        open? @(re-frame/subscribe [::translator-subs/translator-modal-state])
         handle-save #(do (save-actions-data! actions-data @scene-id)
                          (close-window!))
         handle-close #(close-window!)]
     [ui/dialog
-     {:open       (boolean translator-modal-state)
+     {:open       open?
       :on-close   handle-close
       :full-width true
       :max-width  "xl"}
      [ui/dialog-title
       "Phrase Translation"]
      [ui/dialog-content {:class-name "translation-form"}
-      (when (boolean translator-modal-state)
+      (when open?
         [translator-form actions-data])]
      [ui/dialog-actions
       [ui/button {:on-click handle-close}


### PR DESCRIPTION
- move wavesurfer handlers to r/with-let so that they are created only on the component creation. It will prevent the redrawing of every audio wave on every click.

- removed 'normalize-path' - was it doing anything? I hadn't found any place where :origin is set