### PR TITLE
Add text chunks translation forms

### DIFF
--- a/resources/courses/spanish/scenes/book.edn
+++ b/resources/courses/spanish/scenes/book.edn
@@ -1,353 +1,385 @@
 {:assets
- [{:url "/raw/img/library/book/background.jpg", :size 10, :type "image"}
-  {:url "/raw/img/library/book/background2.jpg", :size 10, :type "image"}
-  {:url "/raw/img/elements/squirrel.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/bee.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/tree.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/bear.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/ear.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/eyes.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/magnet.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/iguana.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/fire.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/grapes.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/one.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/nail.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/elephant.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/star.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/nurse.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/hand.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/monkey.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/apple.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/snake.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/sun.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/watermelon.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/ball.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/duck.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/fish.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/lion.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/lemon.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/pencil.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/tomato.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/train.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/shark.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/finger.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/dragon.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/teeth.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/frog.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/rock.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/rose.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/home.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/bed.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/car.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/comb.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/pig.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/eyebrow.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/nino.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/nest.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/orange.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/flower.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/flute.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/strawberry.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/baby.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/boat.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/whale.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/garden.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/juice.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/jamon.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/cat.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/guitar.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/chicken.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/twins.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/giant.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/sunflower.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/chocolate.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/girl.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/boy.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/ostrich.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/yam.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/knot.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/violin.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/cow.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/window.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/key.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/rain.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/cry.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/leaf.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/ice cream.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/ant.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/cheese.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/five.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/fifteen.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/boots.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/fox.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/carrot.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/kimono.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/kayak.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/koala.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/website.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/deer.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/waffles.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/yoyo.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/yogurt.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/egg_yolk.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/xylophone.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/saxophone.png", :size 1, :type "image"}
-  {:url "/raw/img/elements/taxi.png", :size 1, :type "image"}
-  {:url "/raw/audio/l1/a6/L1_A6_Lion_Intro.m4a", :size 2, :type "audio", :alias "librarian books intro"}
-  {:url "/raw/audio/l1/a6/L1_A6_Lion_words.m4a", :size 2, :type "audio", :alias "librarian books words"}
-  {:url "/raw/audio/l1/a6/L1_A6_Vera.m4a", :size 2, :type "audio", :alias "vera books intro"}
-  {:url "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3", :size 2, :type "audio", :alias "lion - 3"}
-  {:url "/raw/audio/l1/a6/lion/2Vamos a leerlo juntos.mp3", :size 2, :type "audio", :alias "lion - 4"}
-  {:url "/raw/audio/l1/a6/lion/2Toca la flecha.mp3", :size 2, :type "audio", :alias "lion - 5"}
-  {:url "/raw/audio/l1/a6/lion/2Muy buen trabajo leyendo.mp3", :size 2, :type "audio", :alias "lion - 6"}
-  {:url "/raw/audio/l1/a6/lion/2La a.mp3", :size 2, :type "audio", :alias "lion - A"}
-  {:url "/raw/audio/l1/a6/lion/2La i.mp3", :size 2, :type "audio", :alias "lion - I"}
-  {:url "/raw/audio/l1/a6/lion/2La o.mp3", :size 2, :type "audio", :alias "lion - O"}
-  {:url "/raw/audio/l1/a6/lion/B.mp3", :size 2, :type "audio", :alias "lion -B"}
-  {:url "/raw/audio/l1/a6/lion/C.mp3", :size 2, :type "audio", :alias "lion -C"}
-  {:url "/raw/audio/l1/a6/lion/Ch.mp3", :size 2, :type "audio", :alias "lion -Ch"}
-  {:url "/raw/audio/l1/a6/lion/D.mp3", :size 2, :type "audio", :alias "lion -D"}
-  {:url "/raw/audio/l1/a6/lion/E.mp3", :size 2, :type "audio", :alias "lion -E"}
-  {:url "/raw/audio/l1/a6/lion/F.mp3", :size 2, :type "audio", :alias "lion -F"}
-  {:url "/raw/audio/l1/a6/lion/G.mp3", :size 2, :type "audio", :alias "lion -G"}
-  {:url "/raw/audio/l1/a6/lion/H.mp3", :size 2, :type "audio", :alias "lion -H"}
-  {:url "/raw/audio/l1/a6/lion/J.mp3", :size 2, :type "audio", :alias "lion -J"}
-  {:url "/raw/audio/l1/a6/lion/K.mp3", :size 2, :type "audio", :alias "lion -K"}
-  {:url "/raw/audio/l1/a6/lion/L.mp3", :size 2, :type "audio", :alias "lion -L"}
-  {:url "/raw/audio/l1/a6/lion/LL.mp3", :size 2, :type "audio", :alias "lion -LL"}
-  {:url "/raw/audio/l1/a6/lion/M.mp3", :size 2, :type "audio", :alias "lion -M"}
-  {:url "/raw/audio/l1/a6/lion/N.mp3", :size 2, :type "audio", :alias "lion -N"}
-  {:url "/raw/audio/l1/a6/lion/P.mp3", :size 2, :type "audio", :alias "lion -P"}
-  {:url "/raw/audio/l1/a6/lion/Qu.mp3", :size 2, :type "audio", :alias "lion -Qu"}
-  {:url "/raw/audio/l1/a6/lion/R.mp3", :size 2, :type "audio", :alias "lion -R"}
-  {:url "/raw/audio/l1/a6/lion/S.mp3", :size 2, :type "audio", :alias "lion -S"}
-  {:url "/raw/audio/l1/a6/lion/T.mp3", :size 2, :type "audio", :alias "lion -T"}
-  {:url "/raw/audio/l1/a6/lion/Tambien C.mp3", :size 2, :type "audio", :alias "lion -Tambien C"}
-  {:url "/raw/audio/l1/a6/lion/También G.mp3", :size 2, :type "audio", :alias "lion -También G"}
-  {:url "/raw/audio/l1/a6/lion/U.mp3", :size 2, :type "audio", :alias "lion -U"}
-  {:url "/raw/audio/l1/a6/lion/V.mp3", :size 2, :type "audio", :alias "lion -V"}
-  {:url "/raw/audio/l1/a6/lion/W.mp3", :size 2, :type "audio", :alias "lion -W"}
-  {:url "/raw/audio/l1/a6/lion/X.mp3", :size 2, :type "audio", :alias "lion -X"}
-  {:url "/raw/audio/l1/a6/lion/Y.mp3", :size 2, :type "audio", :alias "lion -Y"}
-  {:url "/raw/audio/l1/a6/lion/Z.mp3", :size 2, :type "audio", :alias "lion -Z"}
-  {:url "/raw/audio/l1/a6/lion/Ñ.mp3", :size 2, :type "audio", :alias "lion -Ñ"}],
+                [{:url "/raw/img/library/book/background.jpg", :size 10, :type "image"}
+                 {:url "/raw/img/library/book/background2.jpg", :size 10, :type "image"}
+                 {:url "/raw/img/elements/squirrel.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/bee.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/tree.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/bear.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/ear.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/eyes.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/magnet.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/iguana.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/fire.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/grapes.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/one.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/nail.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/elephant.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/star.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/nurse.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/hand.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/monkey.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/apple.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/snake.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/sun.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/watermelon.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/ball.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/duck.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/fish.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/lion.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/lemon.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/pencil.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/tomato.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/train.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/shark.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/finger.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/dragon.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/teeth.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/frog.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/rock.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/rose.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/home.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/bed.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/car.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/comb.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/pig.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/eyebrow.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/nino.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/nest.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/orange.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/flower.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/flute.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/strawberry.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/baby.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/boat.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/whale.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/garden.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/juice.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/jamon.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/cat.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/guitar.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/chicken.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/twins.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/giant.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/sunflower.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/chocolate.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/girl.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/boy.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/ostrich.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/yam.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/knot.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/violin.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/cow.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/window.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/key.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/rain.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/cry.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/leaf.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/ice cream.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/ant.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/cheese.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/five.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/fifteen.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/boots.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/fox.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/carrot.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/kimono.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/kayak.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/koala.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/website.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/deer.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/waffles.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/yoyo.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/yogurt.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/egg_yolk.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/xylophone.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/saxophone.png", :size 1, :type "image"}
+                 {:url "/raw/img/elements/taxi.png", :size 1, :type "image"}
+                 {:url "/raw/audio/l1/a6/L1_A6_Lion_Intro.m4a", :size 2, :type "audio", :alias "librarian books intro"}
+                 {:url "/raw/audio/l1/a6/L1_A6_Lion_words.m4a", :size 2, :type "audio", :alias "librarian books words"}
+                 {:url "/raw/audio/l1/a6/L1_A6_Vera.m4a", :size 2, :type "audio", :alias "vera books intro"}
+                 {:url "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3", :size 2, :type "audio", :alias "lion - 3"}
+                 {:url "/raw/audio/l1/a6/lion/2Vamos a leerlo juntos.mp3", :size 2, :type "audio", :alias "lion - 4"}
+                 {:url "/raw/audio/l1/a6/lion/2Toca la flecha.mp3", :size 2, :type "audio", :alias "lion - 5"}
+                 {:url "/raw/audio/l1/a6/lion/2Muy buen trabajo leyendo.mp3", :size 2, :type "audio", :alias "lion - 6"}
+                 {:url "/raw/audio/l1/a6/lion/2La a.mp3", :size 2, :type "audio", :alias "lion - A"}
+                 {:url "/raw/audio/l1/a6/lion/2La i.mp3", :size 2, :type "audio", :alias "lion - I"}
+                 {:url "/raw/audio/l1/a6/lion/2La o.mp3", :size 2, :type "audio", :alias "lion - O"}
+                 {:url "/raw/audio/l1/a6/lion/B.mp3", :size 2, :type "audio", :alias "lion -B"}
+                 {:url "/raw/audio/l1/a6/lion/C.mp3", :size 2, :type "audio", :alias "lion -C"}
+                 {:url "/raw/audio/l1/a6/lion/Ch.mp3", :size 2, :type "audio", :alias "lion -Ch"}
+                 {:url "/raw/audio/l1/a6/lion/D.mp3", :size 2, :type "audio", :alias "lion -D"}
+                 {:url "/raw/audio/l1/a6/lion/E.mp3", :size 2, :type "audio", :alias "lion -E"}
+                 {:url "/raw/audio/l1/a6/lion/F.mp3", :size 2, :type "audio", :alias "lion -F"}
+                 {:url "/raw/audio/l1/a6/lion/G.mp3", :size 2, :type "audio", :alias "lion -G"}
+                 {:url "/raw/audio/l1/a6/lion/H.mp3", :size 2, :type "audio", :alias "lion -H"}
+                 {:url "/raw/audio/l1/a6/lion/J.mp3", :size 2, :type "audio", :alias "lion -J"}
+                 {:url "/raw/audio/l1/a6/lion/K.mp3", :size 2, :type "audio", :alias "lion -K"}
+                 {:url "/raw/audio/l1/a6/lion/L.mp3", :size 2, :type "audio", :alias "lion -L"}
+                 {:url "/raw/audio/l1/a6/lion/LL.mp3", :size 2, :type "audio", :alias "lion -LL"}
+                 {:url "/raw/audio/l1/a6/lion/M.mp3", :size 2, :type "audio", :alias "lion -M"}
+                 {:url "/raw/audio/l1/a6/lion/N.mp3", :size 2, :type "audio", :alias "lion -N"}
+                 {:url "/raw/audio/l1/a6/lion/P.mp3", :size 2, :type "audio", :alias "lion -P"}
+                 {:url "/raw/audio/l1/a6/lion/Qu.mp3", :size 2, :type "audio", :alias "lion -Qu"}
+                 {:url "/raw/audio/l1/a6/lion/R.mp3", :size 2, :type "audio", :alias "lion -R"}
+                 {:url "/raw/audio/l1/a6/lion/S.mp3", :size 2, :type "audio", :alias "lion -S"}
+                 {:url "/raw/audio/l1/a6/lion/T.mp3", :size 2, :type "audio", :alias "lion -T"}
+                 {:url "/raw/audio/l1/a6/lion/Tambien C.mp3", :size 2, :type "audio", :alias "lion -Tambien C"}
+                 {:url "/raw/audio/l1/a6/lion/También G.mp3", :size 2, :type "audio", :alias "lion -También G"}
+                 {:url "/raw/audio/l1/a6/lion/U.mp3", :size 2, :type "audio", :alias "lion -U"}
+                 {:url "/raw/audio/l1/a6/lion/V.mp3", :size 2, :type "audio", :alias "lion -V"}
+                 {:url "/raw/audio/l1/a6/lion/W.mp3", :size 2, :type "audio", :alias "lion -W"}
+                 {:url "/raw/audio/l1/a6/lion/X.mp3", :size 2, :type "audio", :alias "lion -X"}
+                 {:url "/raw/audio/l1/a6/lion/Y.mp3", :size 2, :type "audio", :alias "lion -Y"}
+                 {:url "/raw/audio/l1/a6/lion/Z.mp3", :size 2, :type "audio", :alias "lion -Z"}
+                 {:url "/raw/audio/l1/a6/lion/Ñ.mp3", :size 2, :type "audio", :alias "lion -Ñ"}],
  :objects
- {:background
-  {:type "background",
-   :src "/raw/img/library/book/background2.jpg",
-   :states
-   {:open {:src "/raw/img/library/book/background.jpg"}, :closed {:src "/raw/img/library/book/background2.jpg"}}},
-  :book
-  {:type "animation",
-   :x 928,
-   :y 1048,
-   :width 1439,
-   :height 960,
-   :scene-name "book",
-   :anim "close_idle",
-   :anim-offset {:x 0, :y -480},
-   :name "book",
-   :scale-x 1,
-   :scale-y 1,
-   :speed 0.3,
-   :start false},
-  :content
-  {:type "transparent",
-   :x 209,
-   :y 89,
-   :transition "content",
-   :children ["letter" "image" "image2" "image3"],
-   :states {:hidden {:type "transparent"}, :visible {:type "group", :opacity 0}}},
-  :image
-  {:type "image",
-   :x 220,
-   :y 570,
-   :width 100,
-   :height 100,
-   :transition "image",
-   :scale-x 2,
-   :scale-y 2,
-   :states {:default {}}},
-  :image2
-  {:type "image",
-   :x 980,
-   :y 150,
-   :width 100,
-   :height 100,
-   :transition "image2",
-   :scale-x 2,
-   :scale-y 2,
-   :states {:default {}}},
-  :image3
-  {:type "image",
-   :x 980,
-   :y 570,
-   :width 100,
-   :height 100,
-   :transition "image3",
-   :scale-x 2,
-   :scale-y 2,
-   :states {:default {}}},
-  :letter
-  {:type "text",
-   :x 220,
-   :y 150,
-   :width 200,
-   :height 200,
-   :font-family "Comic Sans MS",
-   :font-size 180,
-   :shadow-blur 5,
-   :shadow-color "#1a1a1a",
-   :shadow-offset {:x 5, :y 5},
-   :shadow-opacity 0.5,
-   :states {:default {}}},
-  :next-page-arrow
-  {:type "image",
-   :x 1640,
-   :y 92,
-   :width 97,
-   :height 99,
-   :actions {:click {:id "next-page", :on "click", :type "action"}},
-   :scale-x -1,
-   :src "/raw/img/ui/back_button_01.png"},
-  :title-text
-  {:type "text",
-   :x 929,
-   :y 164,
-   :width 680,
-   :height 800,
-   :align "center",
-   :chunks
-   [{:end 2, :start 0}
-    {:end 5, :start 3}
-    {:end 8, :start 5}
-    {:end 11, :start 9}
-    {:end 15, :start 12}
-    {:end 19, :start 16}
-    {:end 21, :start 19}
-    {:end 24, :start 21}
-    {:end 27, :start 25}
-    {:end 29, :start 27}
-    {:end 33, :start 29}],
-   :fill "white",
-   :font-family "Liberation Sans",
-   :font-size 90,
-   :shadow-blur 5,
-   :shadow-color "#1a1a1a",
-   :shadow-offset {:x 5, :y 5},
-   :shadow-opacity 0.5,
-   :states {:hidden {:type "transparent"}, :visible {:type "text"}},
-   :text "El libro de mis primeras palabras",
-   :vertical-align "middle"}},
+                {:background
+                 {:type "background",
+                  :src  "/raw/img/library/book/background2.jpg",
+                  :states
+                        {:open {:src "/raw/img/library/book/background.jpg"}, :closed {:src "/raw/img/library/book/background2.jpg"}}},
+                 :book
+                 {:type        "animation",
+                  :x           928,
+                  :y           1048,
+                  :width       1439,
+                  :height      960,
+                  :scene-name  "book",
+                  :anim        "close_idle",
+                  :anim-offset {:x 0, :y -480},
+                  :name        "book",
+                  :scale-x     1,
+                  :scale-y     1,
+                  :speed       0.3,
+                  :start       false},
+                 :content
+                 {:type       "transparent",
+                  :x          209,
+                  :y          89,
+                  :transition "content",
+                  :children   ["letter" "image" "image2" "image3"],
+                  :states     {:hidden {:type "transparent"}, :visible {:type "group", :opacity 0}}},
+                 :image
+                 {:type       "image",
+                  :x          220,
+                  :y          570,
+                  :width      100,
+                  :height     100,
+                  :transition "image",
+                  :scale-x    2,
+                  :scale-y    2,
+                  :states     {:default {}}},
+                 :image2
+                 {:type       "image",
+                  :x          980,
+                  :y          150,
+                  :width      100,
+                  :height     100,
+                  :transition "image2",
+                  :scale-x    2,
+                  :scale-y    2,
+                  :states     {:default {}}},
+                 :image3
+                 {:type       "image",
+                  :x          980,
+                  :y          570,
+                  :width      100,
+                  :height     100,
+                  :transition "image3",
+                  :scale-x    2,
+                  :scale-y    2,
+                  :states     {:default {}}},
+                 :letter
+                 {:type           "text",
+                  :x              220,
+                  :y              150,
+                  :width          200,
+                  :height         200,
+                  :font-family    "Comic Sans MS",
+                  :font-size      180,
+                  :shadow-blur    5,
+                  :shadow-color   "#1a1a1a",
+                  :shadow-offset  {:x 5, :y 5},
+                  :shadow-opacity 0.5,
+                  :states         {:default {}}},
+                 :next-page-arrow
+                 {:type    "image",
+                  :x       1640,
+                  :y       92,
+                  :width   97,
+                  :height  99,
+                  :actions {:click {:id "next-page", :on "click", :type "action"}},
+                  :scale-x -1,
+                  :src     "/raw/img/ui/back_button_01.png"},
+                 :title-text
+                 {:type           "text",
+                  :x              929,
+                  :y              164,
+                  :width          680,
+                  :height         800,
+                  :align          "center",
+                  :chunks
+                                  [{:end 2, :start 0}
+                                   {:end 5, :start 3}
+                                   {:end 8, :start 5}
+                                   {:end 11, :start 9}
+                                   {:end 15, :start 12}
+                                   {:end 19, :start 16}
+                                   {:end 21, :start 19}
+                                   {:end 24, :start 21}
+                                   {:end 27, :start 25}
+                                   {:end 29, :start 27}
+                                   {:end 33, :start 29}],
+                  :fill           "white",
+                  :font-family    "Liberation Sans",
+                  :font-size      90,
+                  :shadow-blur    5,
+                  :shadow-color   "#1a1a1a",
+                  :shadow-offset  {:x 5, :y 5},
+                  :shadow-opacity 0.5,
+                  :states         {:hidden {:type "transparent"}, :visible {:type "text"}},
+                  :text           "El libro de mis primeras palabras",
+                  :vertical-align "middle"}},
  :scene-objects [["background"] ["book"] ["title-text" "content" "next-page-arrow"]],
  :actions
- {:clear-instruction {:type "remove-flows", :flow-tag "instruction"},
-  :finish-activity
-  {:id "book", :type "finish-activity"},
-  :init-next-page {:type "set-variable", :var-name "next-page-action", :var-value "open-book"},
-  :next-page {:type "action", :from-var [{:var-name "next-page-action", :action-property "id"}]},
-  :open-book
-  {:type "sequence-data",
-   :data
-   [{:id "hidden", :type "state", :target "title-text"}
-    {:type "start-animation", :target "book"}
-    {:id "open_book", :type "animation", :target "book"}
-    {:id "open", :type "state", :target "background"}
-    {:id "idle", :type "add-animation", :target "book"}
-    {:id "renew-current-concept", :type "action"}
-    {:id "visible", :type "state", :target "content"}
-    {:type "empty", :duration 3000}
-    {:to {:opacity 1, :duration 0.5}, :type "transition", :transition-id "content"}
-    {:type "set-variable", :var-name "next-page-action", :var-value "open-next-page"}
-    {:id "read-page", :type "action"}]},
-  :open-next-page
-  {:type "sequence-data",
-   :data
-   [{:to {:opacity 0, :duration 0.5}, :type "transition", :transition-id "content"}
-    {:id "hidden", :type "state", :target "content"}
-    {:id "renew-current-concept", :type "action"}
-    {:id "page", :loop false, :type "animation", :target "book"}
-    {:id "visible", :type "state", :target "content"}
-    {:type "empty", :duration 1500}
-    {:to {:opacity 1, :duration 0.5}, :type "transition", :transition-id "content"}
-    {:id "read-page", :type "action"}]},
-  :read-page
-  {:type "parallel",
-   :data
-   [{:data
-     [{:type "empty", :duration 5000}
-      {:id "default", :type "state", :params {:filter ""}, :target "image"}
-      {:type "empty", :duration 2000}
-      {:id "default", :type "state", :params {:filter ""}, :target "image2"}
-      {:type "empty", :duration 2000}
-      {:id "default", :type "state", :params {:filter ""}, :target "image3"}],
-     :type "sequence-data"}
-    {:type "action", :from-var [{:var-name "current-word", :var-property "book-read-action"}]}]},
-  :read-title
-  {:type "sequence-data",
-   :data
-   [{:id "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3", :type "audio", :start 0.373, :duration 1.773}
-    {:data
-     [{:at 2.826, :end 3.052, :chunk 0, :start 2.826, :duration 0.226}
-      {:at 3.092, :end 3.252, :chunk 1, :start 3.092, :duration 0.16}
-      {:at 3.306, :end 3.492, :chunk 2, :start 3.306, :duration 0.186}
-      {:at 3.692, :end 3.799, :chunk 3, :start 3.692, :duration 0.107}
-      {:at 3.839, :end 4.092, :chunk 4, :start 3.839, :duration 0.253}
-      {:at 4.212, :end 4.399, :chunk 5, :start 4.212, :duration 0.187}
-      {:at 4.465, :end 4.612, :chunk 6, :start 4.465, :duration 0.147}
-      {:at 4.665, :end 4.785, :chunk 7, :start 4.665, :duration 0.12}
-      {:at 4.839, :end 4.972, :chunk 8, :start 4.839, :duration 0.133}
-      {:at 5.039, :end 5.225, :chunk 9, :start 5.039, :duration 0.186}
-      {:at 5.332, :end 5.518, :chunk 10, :start 5.332, :duration 0.186}],
-     :type "text-animation",
-     :audio "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3",
-     :start 2.693,
-     :target "title-text",
-     :duration 2.999,
-     :animation "bounce"}
-    {:id "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3", :type "audio", :start 6.052, :duration 2.532}
-    {:data
-     [{:at 2.826, :end 3.052, :chunk 0, :start 2.826, :duration 0.226}
-      {:at 3.092, :end 3.252, :chunk 1, :start 3.092, :duration 0.16}
-      {:at 3.306, :end 3.492, :chunk 2, :start 3.306, :duration 0.186}
-      {:at 3.692, :end 3.799, :chunk 3, :start 3.692, :duration 0.107}
-      {:at 3.839, :end 4.092, :chunk 4, :start 3.839, :duration 0.253}
-      {:at 4.212, :end 4.399, :chunk 5, :start 4.212, :duration 0.187}
-      {:at 4.465, :end 4.612, :chunk 6, :start 4.465, :duration 0.147}
-      {:at 4.665, :end 4.785, :chunk 7, :start 4.665, :duration 0.12}
-      {:at 4.839, :end 4.972, :chunk 8, :start 4.839, :duration 0.133}
-      {:at 5.039, :end 5.225, :chunk 9, :start 5.039, :duration 0.186}
-      {:at 5.332, :end 5.518, :chunk 10, :start 5.332, :duration 0.186}],
-     :type "text-animation",
-     :audio "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3",
-     :start 2.693,
-     :target "title-text",
-     :duration 2.999,
-     :animation "bounce"}
-    {:id "/raw/audio/l1/a6/L1_A6_Vera.m4a", :type "audio", :start 5.497, :duration 2.201}
-    {:id "/raw/audio/l1/a6/lion/2Vamos a leerlo juntos.mp3", :type "audio", :start 0.348, :duration 2.054}
-    {:id "/raw/audio/l1/a6/lion/2Toca la flecha.mp3", :type "audio", :start 0.52, :duration 4.164}]},
-  :renew-current-concept
-  {:type "sequence-data",
-   :data
-   [{:from ["item-1" "item-2" "item-3"],
-     :type "vars-var-provider",
-     :on-end "finish-activity",
-     :shuffled false,
-     :variables ["current-word"],
-     :provider-id "current-word"}
-    {:type "action", :from-var [{:var-name "current-word", :var-property "book-content-action"}]}]},
-  :renew-words
-  {:type "lesson-var-provider",
-   :from "concepts",
-   :provider-id "words-set",
-   :shuffled false,
-   :variables ["item-1" "item-2" "item-3"]},
-  :start {:type "sequence", :data ["start-activity" "clear-instruction" "renew-words" "init-next-page" "read-title"]},
-  :start-activity {:type "start-activity", :id "book"},
-  :start-background-music {:type "audio", :id "background", :loop true},
-  :stop-activity {:type "stop-activity", :id "book"}},
- :triggers {:back {:on "back", :action "stop-activity"}, :start {:on "start", :action "start"}},
- :metadata {:prev "map", :autostart true},
- :audio {:background "/raw/audio/background/POL-daily-special-short.mp3"}}
+                {:clear-instruction      {:type "remove-flows", :flow-tag "instruction"},
+                 :finish-activity
+                                         {:type "sequence-data", :data [{:id "book", :type "finish-activity"} {:type "scene", :scene-id "library"}]},
+                 :init-next-page         {:type "set-variable", :var-name "next-page-action", :var-value "open-book"},
+                 :next-page
+                                         {:type     "action",
+                                          :from-var [{:var-name "next-page-action", :action-property "id", :possible-values ["open-book" "open-next-page"]}]},
+                 :open-book
+                                         {:type "sequence-data",
+                                          :data
+                                                [{:id "hidden", :type "state", :target "title-text"}
+                                                 {:type "start-animation", :target "book"}
+                                                 {:id "open_book", :type "animation", :target "book"}
+                                                 {:id "open", :type "state", :target "background"}
+                                                 {:id "idle", :type "add-animation", :target "book"}
+                                                 {:id "renew-current-concept", :type "action"}
+                                                 {:id "visible", :type "state", :target "content"}
+                                                 {:type "empty", :duration 3000}
+                                                 {:to {:opacity 1, :duration 0.5}, :type "transition", :transition-id "content"}
+                                                 {:type "set-variable", :var-name "next-page-action", :var-value "open-next-page"}
+                                                 {:id "read-page", :type "action"}]},
+                 :open-next-page
+                                         {:type "sequence-data",
+                                          :data
+                                                [{:to {:opacity 0, :duration 0.5}, :type "transition", :transition-id "content"}
+                                                 {:id "hidden", :type "state", :target "content"}
+                                                 {:id "renew-current-concept", :type "action"}
+                                                 {:id "page", :loop false, :type "animation", :target "book"}
+                                                 {:id "visible", :type "state", :target "content"}
+                                                 {:type "empty", :duration 1500}
+                                                 {:to {:opacity 1, :duration 0.5}, :type "transition", :transition-id "content"}
+                                                 {:id "read-page", :type "action"}]},
+                 :read-page
+                                         {:type "parallel",
+                                          :data
+                                                [{:data
+                                                        [{:type "empty", :duration 5000}
+                                                         {:id "default", :type "state", :params {:filter ""}, :target "image"}
+                                                         {:type "empty", :duration 2000}
+                                                         {:id "default", :type "state", :params {:filter ""}, :target "image2"}
+                                                         {:type "empty", :duration 2000}
+                                                         {:id "default", :type "state", :params {:filter ""}, :target "image3"}],
+                                                  :type "sequence-data"}
+                                                 {:id "read-page-current-concept", :type "action"}]},
+                 :read-page-current-concept
+                                         {:type               "action",
+                                          :phrase             "read-page",
+                                          :phrase-description "Read concept words",
+                                          :from-var           [{:var-name "current-word", :var-property "book-read-action"}]},
+                 :read-title
+                                         {:type               "sequence-data",
+                                          :data
+                                                              [{:id          "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3",
+                                                                :type        "audio",
+                                                                :start       0.373,
+                                                                :duration    1.773,
+                                                                :phrase-text "Do you see this title?"}
+                                                               {:data
+                                                                             [{:at 2.826, :end 3.052, :chunk 0, :start 2.826, :duration 0.226}
+                                                                              {:at 3.092, :end 3.252, :chunk 1, :start 3.092, :duration 0.16}
+                                                                              {:at 3.306, :end 3.492, :chunk 2, :start 3.306, :duration 0.186}
+                                                                              {:at 3.692, :end 3.799, :chunk 3, :start 3.692, :duration 0.107}
+                                                                              {:at 3.839, :end 4.092, :chunk 4, :start 3.839, :duration 0.253}
+                                                                              {:at 4.212, :end 4.399, :chunk 5, :start 4.212, :duration 0.187}
+                                                                              {:at 4.465, :end 4.612, :chunk 6, :start 4.465, :duration 0.147}
+                                                                              {:at 4.665, :end 4.785, :chunk 7, :start 4.665, :duration 0.12}
+                                                                              {:at 4.839, :end 4.972, :chunk 8, :start 4.839, :duration 0.133}
+                                                                              {:at 5.039, :end 5.225, :chunk 9, :start 5.039, :duration 0.186}
+                                                                              {:at 5.332, :end 5.518, :chunk 10, :start 5.332, :duration 0.186}],
+                                                                :type        "text-animation",
+                                                                :audio       "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3",
+                                                                :start       2.693,
+                                                                :target      "title-text",
+                                                                :duration    2.999,
+                                                                :animation   "bounce",
+                                                                :phrase-text "My first words book"}
+                                                               {:id          "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3",
+                                                                :type        "audio",
+                                                                :start       6.052,
+                                                                :duration    2.532,
+                                                                :phrase-text "The title of this book is"}
+                                                               {:data
+                                                                             [{:at 2.826, :end 3.052, :chunk 0, :start 2.826, :duration 0.226}
+                                                                              {:at 3.092, :end 3.252, :chunk 1, :start 3.092, :duration 0.16}
+                                                                              {:at 3.306, :end 3.492, :chunk 2, :start 3.306, :duration 0.186}
+                                                                              {:at 3.692, :end 3.799, :chunk 3, :start 3.692, :duration 0.107}
+                                                                              {:at 3.839, :end 4.092, :chunk 4, :start 3.839, :duration 0.253}
+                                                                              {:at 4.212, :end 4.399, :chunk 5, :start 4.212, :duration 0.187}
+                                                                              {:at 4.465, :end 4.612, :chunk 6, :start 4.465, :duration 0.147}
+                                                                              {:at 4.665, :end 4.785, :chunk 7, :start 4.665, :duration 0.12}
+                                                                              {:at 4.839, :end 4.972, :chunk 8, :start 4.839, :duration 0.133}
+                                                                              {:at 5.039, :end 5.225, :chunk 9, :start 5.039, :duration 0.186}
+                                                                              {:at 5.332, :end 5.518, :chunk 10, :start 5.332, :duration 0.186}],
+                                                                :type        "text-animation",
+                                                                :audio       "/raw/audio/l1/a6/lion/2Mis primeras palabras.mp3",
+                                                                :start       2.693,
+                                                                :target      "title-text",
+                                                                :duration    2.999,
+                                                                :animation   "bounce",
+                                                                :phrase-text "My first words book"}
+                                                               {:id          "/raw/audio/l1/a6/L1_A6_Vera.m4a",
+                                                                :type        "audio",
+                                                                :start       5.497,
+                                                                :duration    2.201,
+                                                                :phrase-text "My first words book."}
+                                                               {:id          "/raw/audio/l1/a6/lion/2Vamos a leerlo juntos.mp3",
+                                                                :type        "audio",
+                                                                :start       0.348,
+                                                                :duration    2.054,
+                                                                :phrase-text "Vamos a leerlo juntos!"}
+                                                               {:id          "/raw/audio/l1/a6/lion/2Toca la flecha.mp3",
+                                                                :type        "audio",
+                                                                :start       0.52,
+                                                                :duration    4.164,
+                                                                :phrase-text "Touch the arrow to turn the page."}],
+                                          :phrase             "read-title",
+                                          :phrase-description "Read title"},
+                 :renew-current-concept
+                                         {:type "sequence-data",
+                                          :data
+                                                [{:from        ["item-1" "item-2" "item-3"],
+                                                  :type        "vars-var-provider",
+                                                  :on-end      "finish-activity",
+                                                  :shuffled    false,
+                                                  :variables   ["current-word"],
+                                                  :provider-id "current-word"}
+                                                 {:type "action", :from-var [{:var-name "current-word", :var-property "book-content-action"}]}]},
+                 :renew-words
+                                         {:type        "lesson-var-provider",
+                                          :from        "concepts",
+                                          :provider-id "words-set",
+                                          :shuffled    false,
+                                          :variables   ["item-1" "item-2" "item-3"]},
+                 :start-activity         {:type "start-activity", :id "book"},
+                 :start-background-music {:type "audio", :id "background", :loop true},
+                 :start-scene
+                                         {:type "sequence", :data ["start-activity" "clear-instruction" "renew-words" "init-next-page" "read-title"]},
+                 :stop-activity          {:type "stop-activity", :id "book"}},
+ :triggers      {:back {:on "back", :action "stop-activity"}, :start {:on "start", :action "start-scene"}},
+ :metadata      {:prev "map", :autostart true},
+ :audio         {:background "/raw/audio/background/POL-daily-special-short.mp3"}}

--- a/src/cljs/webchange/editor/events.cljs
+++ b/src/cljs/webchange/editor/events.cljs
@@ -245,6 +245,11 @@
     {:db (assoc-in db [:scenes scene-id :actions] actions)}))
 
 (re-frame/reg-event-fx
+  ::reset-scene-objects
+  (fn [{:keys [db]} [_ scene-id objects]]
+    {:db (assoc-in db [:scenes scene-id :objects] objects)}))
+
+(re-frame/reg-event-fx
   ::reset-asset
   (fn [{:keys [db]} [_]]
     {:db (update-in db [:editor] dissoc :selected-asset)}))

--- a/src/cljs/webchange/editor_v2/diagram/modes/translation/widget_config_button.cljs
+++ b/src/cljs/webchange/editor_v2/diagram/modes/translation/widget_config_button.cljs
@@ -1,0 +1,32 @@
+(ns webchange.editor-v2.diagram.modes.translation.widget-config-button
+  (:require
+    [cljs-react-material-ui.icons :as ic]
+    [reagent.core :as r]
+    [re-frame.core :as re-frame]
+    [webchange.editor-v2.translator.translator-form.state.actions :as translator-form.actions]
+    [webchange.editor-v2.translator.text.chunks :as chunks]))
+
+(def fab (r/adapt-react-class (aget js/MaterialUI "Fab")))
+
+(defn- get-styles
+  []
+  {:config-button {:right    "0"
+                   :top      "0"
+                   :position "absolute"
+                   :margin   "10px"
+                   :width    "36px"
+                   :height   "36px"}})
+
+(defn config-button
+  [node-data]
+  (let [action-data (:data node-data)
+        type (-> action-data :type keyword)
+        styles (get-styles)]
+    (when (= :text-animation type)
+      [fab {:style    (:config-button styles)
+            :size     "small"
+            :on-click (fn [event]
+                        (.stopPropagation event)
+                        (re-frame/dispatch [::translator-form.actions/set-current-phrase-action node-data])
+                        (re-frame/dispatch [::chunks/open action-data]))}
+       [ic/settings]])))

--- a/src/cljs/webchange/editor_v2/diagram/modes/translation/widget_data.cljs
+++ b/src/cljs/webchange/editor_v2/diagram/modes/translation/widget_data.cljs
@@ -7,6 +7,7 @@
     [webchange.editor-v2.diagram.modes.translation.widget-menu :refer [menu]]
     [webchange.editor-v2.diagram.modes.translation.widget-phrase :refer [phrase]]
     [webchange.editor-v2.diagram.modes.translation.widget-play-button :refer [play-button]]
+    [webchange.editor-v2.diagram.modes.translation.widget-config-button :refer [config-button]]
     [webchange.editor-v2.diagram.modes.translation.widget-loop-icon :refer [loop-icon]]
     [webchange.editor-v2.graph-builder.utils.node-data :refer [speech-node? concept-action-node?]]
     [webchange.editor-v2.translator.translator-form.state.actions :as translator-form.actions]))
@@ -40,7 +41,8 @@
                  :style    (merge custom-wrapper/node-style
                                   (:node styles))}
            [play-button node-data]
-           [loop-icon node-data]]
+           [loop-icon node-data]
+           [config-button node-data]]
           (r/children this))))
 
 (defn get-widget-data

--- a/src/cljs/webchange/editor_v2/events.cljs
+++ b/src/cljs/webchange/editor_v2/events.cljs
@@ -4,7 +4,8 @@
     [ajax.core :refer [json-request-format json-response-format]]
     [webchange.interpreter.events :as ie]
     [webchange.editor-v2.translator.state.window :as translator.window]
-    [webchange.editor-v2.translator.translator-form.state.actions :as translator-form.actions]))
+    [webchange.editor-v2.translator.translator-form.state.actions :as translator-form.actions]
+    [webchange.editor-v2.translator.text.views :as translator.text]))
 
 (re-frame/reg-event-fx
   ::init-editor
@@ -45,6 +46,12 @@
   (fn [{:keys [_]} [_ action-node]]
     {:dispatch-n (list [::translator-form.actions/set-current-dialog-action action-node]
                        [::translator.window/open])}))
+
+(re-frame/reg-event-fx
+  ::show-configure-object-form
+  (fn [{:keys [_]} [_ object-info]]
+    {:dispatch-n (list [::translator.text/set-current-dialog-text object-info]
+                       [::translator.text/open])}))
 
 (re-frame/reg-event-fx
   ::load-course-info

--- a/src/cljs/webchange/editor_v2/graph_builder/scene_parser/scene_parser_objects.cljs
+++ b/src/cljs/webchange/editor_v2/graph_builder/scene_parser/scene_parser_objects.cljs
@@ -8,11 +8,12 @@
                        (fn [[_ {:keys [id on]}]]
                          {:name    on
                           :handler id})
-                       (:actions object-data))]
+                       (:actions object-data))
+        object-root-info (if (= "text" (:type object-data)) {:name :default :handler :default})]
     (assoc {} object-name (create-graph-node {:entity      :object
                                               :data        object-data
                                               :path        [object-name]
-                                              :connections actions-data}))))
+                                              :connections (conj actions-data object-root-info)}))))
 
 (defn parse-objects
   [scene-data]

--- a/src/cljs/webchange/editor_v2/graph_builder/utils/node_data.cljs
+++ b/src/cljs/webchange/editor_v2/graph_builder/utils/node_data.cljs
@@ -51,6 +51,8 @@
   (let [node-type (get-node-type node-data)]
     (or (= "audio" node-type)
         (and (= "animation-sequence" node-type)
+             (contains? (:data node-data) :audio))
+        (and (= "text-animation" node-type)
              (contains? (:data node-data) :audio)))))
 
 (defn concept-action-node?

--- a/src/cljs/webchange/editor_v2/layout/views.cljs
+++ b/src/cljs/webchange/editor_v2/layout/views.cljs
@@ -3,6 +3,7 @@
     [webchange.editor-v2.concepts.views :refer [delete-dataset-item-modal]]
     [webchange.editor-v2.layout.toolbar.views :refer [toolbar]]
     [webchange.editor-v2.translator.views-modal :refer [translator-modal]]
+    [webchange.editor-v2.translator.text.views :refer [configuration-modal]]
     [reagent.core :as r]))
 
 (defn- get-styles
@@ -20,6 +21,7 @@
   []
   [:div
    [translator-modal]
+   [configuration-modal]
    [delete-dataset-item-modal]])
 
 (defn layout

--- a/src/cljs/webchange/editor_v2/translator/state/window.cljs
+++ b/src/cljs/webchange/editor_v2/translator/state/window.cljs
@@ -19,8 +19,7 @@
   ::open
   (fn [{:keys [db]} [_]]
     {:db         (assoc-in db (path-to-db [:translator-modal-state]) true)
-     :dispatch-n (list [:complete-request :login]
-                       [::translator-form/init-state])}))
+     :dispatch [::translator-form/init-state]}))
 
 (re-frame/reg-event-fx
   ::close

--- a/src/cljs/webchange/editor_v2/translator/text/chunks.cljs
+++ b/src/cljs/webchange/editor_v2/translator/text/chunks.cljs
@@ -1,0 +1,148 @@
+(ns webchange.editor-v2.translator.text.chunks
+  (:require
+    [cljs-react-material-ui.reagent :as ui]
+    [re-frame.core :as re-frame]
+    [reagent.core :as r]
+    [webchange.editor-v2.translator.translator-form.state.actions :as translator-form.actions]
+    [webchange.editor-v2.translator.translator-form.state.scene :as translator-form.scene]
+    [webchange.editor-v2.translator.text.core :refer [chunks->parts]]
+    [webchange.editor-v2.components.audio-wave-form.views :refer [audio-wave-form]]))
+
+(def modal-state-path [:editor-v2 :translator :text :chunks-modal-state])
+(def selected-chunk-path [:editor-v2 :translator :text :chunks :selected])
+(def audio-path [:editor-v2 :translator :text :chunks :audio])
+(def bounds-path [:editor-v2 :translator :text :chunks :bounds])
+(def data-path [:editor-v2 :translator :text :chunks :data])
+
+(defn bound
+  [{:keys [start end]} value]
+  (cond
+    (> start value) start
+    (< end value) end
+    :else value))
+
+(re-frame/reg-sub
+  ::modal-state
+  (fn [db]
+    (-> db
+        (get-in modal-state-path)
+        boolean)))
+
+(re-frame/reg-sub
+  ::text-object
+  (fn []
+    [(re-frame/subscribe [::translator-form.actions/current-phrase-action])
+     (re-frame/subscribe [::translator-form.scene/objects-data])])
+  (fn [[{:keys [target]} objects]]
+    (get objects (keyword target))))
+
+(re-frame/reg-sub
+  ::selected-chunk
+  (fn [db]
+    (get-in db selected-chunk-path)))
+
+(re-frame/reg-sub
+  ::selected-audio
+  (fn [db]
+    (let [index (get-in db selected-chunk-path)
+          audio (get-in db audio-path)
+          data (get-in db data-path)
+          bounds (get-in db bounds-path)
+          {:keys [start end]} (->> data (filter #(= index (:chunk %))) first)]
+      {:url   audio
+       :start (bound bounds start)
+       :end   (bound bounds end)})))
+
+(re-frame/reg-event-fx
+  ::open
+  (fn [{:keys [db]} [_ {:keys [audio start duration data target]}]]
+    (let [chunks-count (-> (translator-form.scene/objects-data db)
+                           (get (keyword target))
+                           (get :chunks)
+                           count)
+          filtered-data (remove #(<= chunks-count (:chunk %)) data)]
+      {:db       (-> db
+                     (assoc-in modal-state-path true)
+                     (assoc-in data-path filtered-data)
+                     (assoc-in audio-path audio)
+                     (assoc-in bounds-path {:start start :end (+ start duration)}))
+       :dispatch [::select-chunk 0]})))
+
+(re-frame/reg-event-fx
+  ::cancel
+  (fn [{:keys [db]} [_]]
+    {:db (assoc-in db modal-state-path false)}))
+
+(re-frame/reg-event-fx
+  ::apply
+  (fn [{:keys [db]} [_]]
+    (let [data (get-in db data-path)]
+      {:db       (assoc-in db modal-state-path false)
+       :dispatch [::translator-form.actions/update-action :phrase {:data data}]})))
+
+(re-frame/reg-event-fx
+  ::select-chunk
+  (fn [{:keys [db]} [_ index]]
+    {:db (assoc-in db selected-chunk-path index)}))
+
+(re-frame/reg-event-fx
+  ::select-audio
+  (fn [{:keys [db]} [_ {:keys [start end duration]}]]
+    (let [index (get-in db selected-chunk-path)
+          chunk {:at       start
+                 :start    start
+                 :end      end
+                 :chunk    index
+                 :duration duration}
+          chunks (as-> (get-in db data-path) c
+                       (remove #(= index (:chunk %)) c)
+                       (conj c chunk)
+                       (sort-by :chunk c))]
+      {:db (assoc-in db data-path chunks)})))
+
+(defn text-chunks-form
+  []
+  (let [text-object @(re-frame/subscribe [::text-object])
+        selected-chunk @(re-frame/subscribe [::selected-chunk])
+        selected-audio @(re-frame/subscribe [::selected-audio])
+        parts (chunks->parts (:text text-object) (:chunks text-object))]
+    [:div
+     [ui/grid {:container true
+               :spacing   16
+               :justify   "space-between"}
+      [ui/grid {:item true :xs 12}
+       [ui/card-content
+        [audio-wave-form (merge selected-audio
+                                {:height         96
+                                 :on-change      #(re-frame/dispatch [::select-audio %])
+                                 :show-controls? true})]]]
+      [ui/grid {:item true :xs 8}
+       (for [[index part] (map-indexed vector parts)]
+         [ui/chip {:key      index
+                   :label    part
+                   :color    (if (= index selected-chunk) "primary" "secondary")
+                   :on-click #(re-frame/dispatch [::select-chunk index])}])]]]))
+
+(defn text-chunks-modal
+  []
+  (let [open? @(re-frame/subscribe [::modal-state])
+        cancel #(re-frame/dispatch [::cancel])
+        apply #(re-frame/dispatch [::apply])]
+    (when open?
+      [ui/dialog
+       {:open       true
+        :on-close   cancel
+        :full-width true
+        :max-width  "xl"}
+       [ui/dialog-title
+        "Configure text"]
+       [ui/dialog-content {:class-name "translation-form"}
+        [text-chunks-form]]
+       [ui/dialog-actions
+        [ui/button {:on-click cancel}
+         "Cancel"]
+        [:div {:style {:position "relative"}}
+         [ui/button {:color    "secondary"
+                     :variant  "contained"
+                     :on-click apply}
+          "Apply"]]]])))

--- a/src/cljs/webchange/editor_v2/translator/text/core.cljs
+++ b/src/cljs/webchange/editor_v2/translator/text/core.cljs
@@ -1,0 +1,25 @@
+(ns webchange.editor-v2.translator.text.core
+  (:require
+    [clojure.string :refer [index-of]]))
+
+(defn- part->chunk
+  [phrase part start]
+  (let [start (index-of phrase part start)
+        end (+ start (count part))]
+    {:start start :end end}))
+
+(defn parts->chunks
+  [phrase parts]
+  (loop [idx 0
+         tail parts
+         chunks []]
+    (if (empty? tail)
+      chunks
+      (let [chunk (part->chunk phrase (first tail) idx)]
+        (recur (:end chunk)
+               (rest tail)
+               (conj chunks chunk))))))
+
+(defn chunks->parts
+  [phrase chunks]
+  (map #(subs phrase (:start %) (:end %)) chunks))

--- a/src/cljs/webchange/editor_v2/translator/text/views.cljs
+++ b/src/cljs/webchange/editor_v2/translator/text/views.cljs
@@ -1,0 +1,142 @@
+(ns webchange.editor-v2.translator.text.views
+  (:require
+    [cljs-react-material-ui.reagent :as ui]
+    [re-frame.core :as re-frame]
+    [reagent.core :as r]
+    [webchange.editor-v2.components.confirm-dialog.views :refer [confirm-dialog]]
+    [webchange.editor-v2.translator.translator-form.state.form :as translator-form]
+    [webchange.editor-v2.translator.translator-form.state.scene :as translator-form.scene]
+    [webchange.editor-v2.translator.text.core :refer [parts->chunks chunks->parts]]))
+
+(def modal-state-path [:editor-v2 :translator :text :configuration-modal-state])
+(def confirm-modal-state-path [:editor-v2 :translator :text :confirm-modal-state])
+(def current-text-info-path [:editor-v2 :translator :text :current-text-info])
+
+;; Subs
+
+(re-frame/reg-sub
+  ::modal-state
+  (fn [db]
+    (-> db
+        (get-in modal-state-path)
+        boolean)))
+
+(re-frame/reg-sub
+  ::confirm-modal-state
+  (fn [db]
+    (-> db
+        (get-in confirm-modal-state-path)
+        boolean)))
+
+(re-frame/reg-sub
+  ::current-dialog-text-info
+  (fn [db]
+    (get-in db current-text-info-path)))
+
+(re-frame/reg-sub
+  ::current-dialog-text
+  (fn []
+    [(re-frame/subscribe [::current-dialog-text-info])
+     (re-frame/subscribe [::translator-form.scene/objects-data])])
+  (fn [[{:keys [path]} objects]]
+    (get-in objects path)))
+
+;; Events
+
+(re-frame/reg-event-fx
+  ::open
+  (fn [{:keys [db]} [_]]
+    {:db       (assoc-in db modal-state-path true)
+     :dispatch [::translator-form/init-state]}))
+
+(re-frame/reg-event-fx
+  ::close
+  (fn [{:keys [db]} [_]]
+    {:db       (assoc-in db modal-state-path false)
+     :dispatch [::translator-form/reset-state]}))
+
+(re-frame/reg-event-fx
+  ::save
+  (fn [_ _]
+    {:dispatch-n (list [::translator-form/save-changes] [::close])}))
+
+(re-frame/reg-event-fx
+  ::set-current-dialog-text
+  (fn [{:keys [db]} [_ text-object-info]]
+    {:db (assoc-in db current-text-info-path text-object-info)}))
+
+(re-frame/reg-event-fx
+  ::set-text
+  (fn [{:keys [db]} [_ text]]
+    (let [{path :path} (get-in db current-text-info-path)]
+      (let [parts (clojure.string/split text #" ")
+            chunks (parts->chunks text parts)]
+        {:dispatch [::translator-form.scene/update-object path {:text text :chunks chunks}]}))))
+
+(re-frame/reg-event-fx
+  ::set-parts
+  (fn [{:keys [db]} [_ str-value]]
+    (let [{path :path} (get-in db current-text-info-path)
+          original (-> db (translator-form.scene/objects-data) (get-in path) :text)
+          original-stripped (clojure.string/replace original #" " "")
+          value-stripped (clojure.string/replace str-value #" " "")]
+      (when (= original-stripped value-stripped)
+        (let [parts (clojure.string/split str-value #" ")
+              chunks (parts->chunks original parts)]
+          {:dispatch [::translator-form.scene/update-object path {:chunks chunks}]})))))
+
+(def text-input-params {:placeholder "Enter description text"
+                        :variant     "outlined"
+                        :margin      "normal"
+                        :multiline   true
+                        :full-width  true})
+
+(defn configuration-form
+  []
+  (let [current-dialog-text @(re-frame/subscribe [::current-dialog-text])
+        origin-text (:text current-dialog-text)
+        parts (chunks->parts origin-text (:chunks current-dialog-text))
+        set-text #(re-frame/dispatch [::set-text (.. % -target -value)])
+        set-parts #(re-frame/dispatch [::set-parts (.. % -target -value)])]
+    [:div
+     [ui/grid {:container true
+               :spacing   16
+               :justify   "space-between"}
+      [ui/grid {:item true :xs 8}
+       [ui/text-field (merge text-input-params
+                             {:label     "Origin"
+                              :value     origin-text
+                              :on-change set-text})]]
+      [ui/grid {:item true :xs 8}
+       (for [part parts]
+         [ui/chip {:label part}])]
+      [ui/grid {:item true :xs 8}
+       [ui/text-field (merge text-input-params
+                             {:label           "Parts"
+                              :value           (clojure.string/join " " parts)
+                              :on-change       set-parts
+                              :helper-text "Use space to divide text into chunks"})]]]]))
+
+(defn configuration-modal
+  []
+  (let [open? @(re-frame/subscribe [::modal-state])
+        save #(re-frame/dispatch [::save])
+        close #(re-frame/dispatch [::close])]
+    (when open?
+      [ui/dialog
+       {:open       true
+        :on-close   close
+        :full-width true
+        :max-width  "xl"}
+       [ui/dialog-title
+        "Configure text"]
+       [ui/dialog-content {:class-name "translation-form"}
+        [configuration-form]]
+       [ui/dialog-actions
+        [ui/button {:on-click close}
+         "Cancel"]
+        [:div {:style {:position "relative"}}
+         [ui/button {:color    "secondary"
+                     :variant  "contained"
+                     :on-click save}
+          "Save"]]]])))

--- a/src/cljs/webchange/editor_v2/translator/translator_form/state/form.cljs
+++ b/src/cljs/webchange/editor_v2/translator/translator_form/state/form.cljs
@@ -41,9 +41,11 @@
 
           scene-id (translator-form.scene/scene-id db)
           actions (translator-form.scene/actions-data db)
-          assets (translator-form.scene/assets-data db)]
+          assets (translator-form.scene/assets-data db)
+          objects (translator-form.scene/objects-data db)]
       {:dispatch-n (->> edited-concepts
                         (map (fn [[id {:keys [data]}]] [::editor/update-dataset-item id data]))
                         (concat (list [::editor/reset-scene-actions scene-id actions]
                                       [::editor/reset-scene-assets scene-id assets]
+                                      [::editor/reset-scene-objects scene-id objects]
                                       [::editor/save-current-scene scene-id])))})))

--- a/src/cljs/webchange/editor_v2/translator/translator_form/state/scene.cljs
+++ b/src/cljs/webchange/editor_v2/translator/translator_form/state/scene.cljs
@@ -60,6 +60,10 @@
   (fn [[assets-data]]
     (filter #(= (:type %) "audio") assets-data)))
 
+(defn objects-data
+  [db]
+  (-> db scene-data :objects))
+
 (re-frame/reg-sub
   ::objects-data
   (fn []
@@ -136,4 +140,13 @@
           action-data (get-in actions-data action-path)
           updated-data (merge action-data data-patch)]
       {:db         (assoc-in db (path-to-db (concat [:scene :data :actions] action-path)) updated-data)
+       :dispatch-n (list [::set-changes])})))
+
+(re-frame/reg-event-fx
+  ::update-object
+  (fn [{:keys [db]} [_ object-path data-patch]]
+    (let [objects-data (objects-data db)
+          object-data (get-in objects-data object-path)
+          updated-data (merge object-data data-patch)]
+      {:db         (assoc-in db (path-to-db (concat [:scene :data :objects] object-path)) updated-data)
        :dispatch-n (list [::set-changes])})))

--- a/src/cljs/webchange/editor_v2/translator/translator_form/views_form.cljs
+++ b/src/cljs/webchange/editor_v2/translator/translator_form/views_form.cljs
@@ -12,6 +12,7 @@
     [webchange.editor-v2.translator.translator-form.views-form-phrase :refer [phrase-block]]
     [webchange.editor-v2.translator.translator-form.views-form-play-phrase :refer [play-phrase-block]]
     [webchange.editor-v2.translator.translator-form.views-form-target :refer [target-block]]
+    [webchange.editor-v2.translator.text.chunks :refer [text-chunks-modal]]
     [webchange.ui.theme :refer [get-in-theme]]))
 
 (defn- get-styles
@@ -35,4 +36,5 @@
         [phrase-block]
         [audios-block]]
        [ui/typography {:variant "subtitle1"}
-        "Select action on diagram"])]))
+        "Select action on diagram"])
+     [text-chunks-modal]]))

--- a/test/cljs/webchange/editor_v2/graph_builder/graph/data/book/dialog__read_title.cljs
+++ b/test/cljs/webchange/editor_v2/graph_builder/graph/data/book/dialog__read_title.cljs
@@ -4,10 +4,18 @@
                           :path        [:read-title 4]
                           :entity      :action
                           :children    []
-                          :connections #{{:previous :read-title-2
+                          :connections #{{:previous :read-title-3
                                           :name     "next"
                                           :sequence :read-title
                                           :handler  :read-title-5}}}
+           :read-title-3 {:data        {:phrase-text "“My first words book”"}
+                          :path        [:read-title 3]
+                          :entity      :action
+                          :children    []
+                          :connections #{{:previous :read-title-2
+                                          :name     "next"
+                                          :sequence :read-title
+                                          :handler  :read-title-4}}}
            :read-title-6 {:data        {:phrase-text "Touch the arrow to turn the page."}
                           :path        [:read-title 6]
                           :entity      :action
@@ -28,12 +36,20 @@
                           :connections #{{:previous :root
                                           :name     "next"
                                           :sequence :read-title
-                                          :handler  :read-title-2}}}
-           :read-title-2 {:data        {:phrase-text "The title of this book is"}
-                          :path        [:read-title 2]
+                                          :handler  :read-title-1}}}
+           :read-title-1 {:data        {:phrase-text "“My first words book”"},
+                          :path        [:read-title 1]
                           :entity      :action
                           :children    []
                           :connections #{{:previous :read-title-0
                                           :name     "next"
                                           :sequence :read-title
-                                          :handler  :read-title-4}}}})
+                                          :handler  :read-title-2}}}
+           :read-title-2 {:data        {:phrase-text "The title of this book is"}
+                          :path        [:read-title 2]
+                          :entity      :action
+                          :children    []
+                          :connections #{{:previous :read-title-1
+                                          :name     "next"
+                                          :sequence :read-title
+                                          :handler  :read-title-3}}}})


### PR DESCRIPTION
1. Add text chunk configuration form:
<img width="347" alt="Снимок экрана 2020-06-19 в 17 08 03" src="https://user-images.githubusercontent.com/915276/85143850-59685800-b25b-11ea-913a-1d3e37b4e7df.png">
<img width="1329" alt="Снимок экрана 2020-06-19 в 17 14 35" src="https://user-images.githubusercontent.com/915276/85143875-5f5e3900-b25b-11ea-83e2-06f9273dbc98.png">

2. Show text-animation action with "settings" icon on phrase translation form:
<img width="189" alt="Снимок экрана 2020-06-19 в 17 15 00" src="https://user-images.githubusercontent.com/915276/85143936-7e5ccb00-b25b-11ea-89ec-20092b1beeae.png">

3. Add configure text chunks form:
<img width="1340" alt="Снимок экрана 2020-06-19 в 17 15 13" src="https://user-images.githubusercontent.com/915276/85144028-a3513e00-b25b-11ea-960d-15e745fa5492.png">
