### PR TITLE
Fix PIXI settings

### DIFF
--- a/src/cljs/webchange/interpreter/pixi.cljs
+++ b/src/cljs/webchange/interpreter/pixi.cljs
@@ -4,6 +4,7 @@
 
 (def PIXI (.. pixi -PIXI))
 
+(set! (.. PIXI -settings -FAIL_IF_MAJOR_PERFORMANCE_CAVEAT) false)
 
 (def Application (.. PIXI -Application))
 (def Loader (.. PIXI -Loader))


### PR DESCRIPTION
With the Chrome update to version 87 (or for some other reason, I don't know for sure), I ran into an error creating a `webgl` context with the `failIfMajorPerformanceCaveat: true` option.

[HTMLCanvasElement.getContext()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext):
> **failIfMajorPerformanceCaveat**: Boolean that indicates if a context will be created if the system performance is low or if no hardware GPU is available

Currently, I set it to `false` to force webgl context creation. But maybe we still need a fallback to `canvas` context?